### PR TITLE
Use JGit in favor of shelling to git

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main datomic.codeq.core
   :plugins [[lein-tar "1.1.0"]]
+  :repositories [["jgit-repository" "https://repo.eclipse.org/content/groups/releases/"]]
   :dependencies [[com.datomic/datomic-free "0.8.4020.24"]
                  [commons-codec "1.7"]
-                 [org.clojure/clojure "1.5.1"]]
+                 [org.clojure/clojure "1.5.1"]
+                 [org.eclipse.jgit/org.eclipse.jgit "3.0.3.201309161630-r"]]
   :source-paths ["src" "examples/src"])

--- a/src/datomic/codeq/core.clj
+++ b/src/datomic/codeq/core.clj
@@ -171,7 +171,6 @@
        :db/valueType :db.type/ref
        :db/cardinality :db.cardinality/one
        :db/doc "Git object (tree/blob) in a tree node"
-       :db/index true
        :db.install/_attribute :db.part/db}
 
       {:db/id #db/id[:db.part/db]
@@ -317,7 +316,7 @@
           (some #(let [{eid :e} %]
                    (if (seq (d/datoms db :eavt eid :node/filename filename-id))
                      eid))
-                (d/datoms db :avet :node/object object-id)))
+                (d/datoms db :vaet object-id :node/object)))
 
         walker-fn
         (fn [{:keys [sha type path filename parent]}]

--- a/src/datomic/codeq/git.clj
+++ b/src/datomic/codeq/git.clj
@@ -1,0 +1,116 @@
+
+(ns datomic.codeq.git
+  (:import [org.eclipse.jgit.lib FileMode ObjectLoader Ref Repository RepositoryBuilder]
+           [org.eclipse.jgit.revwalk RevCommit RevSort RevTree RevWalk]
+           org.eclipse.jgit.revwalk.filter.RevFilter
+           org.eclipse.jgit.treewalk.TreeWalk
+           org.eclipse.jgit.storage.file.FileRepositoryBuilder))
+
+
+(defn ^Repository open-existing-repo
+  "Open an exisiting git repository by
+   scanning GIT_* environment variables
+   and scanning up the file system tree."
+  []
+  (.. (FileRepositoryBuilder.)
+      (readEnvironment)
+      (findGitDir)
+      (build)))
+
+
+(defn get-origin-uri
+  "Lookup the uri for the 'origin' remote, and
+   extract the repository name. Returns [uri name]."
+  [^Repository repo]
+  (if-let [^String uri (.. repo (getConfig) (getString "remote" "origin" "url"))]
+    (let [noff (.lastIndexOf uri "/")
+          noff (if (not (pos? noff)) (.lastIndexOf uri ":") noff)
+          name (subs uri (inc noff))
+          _ (assert (pos? (count name)) "Can't find remote origin")
+          name (if (.endsWith name ".git") (subs name 0 (.indexOf name ".")) name)]
+      [uri name])
+    (throw (ex-info "No remote 'origin' configured for this repository."
+                    {:remotes (.. repo (getConfig) (getSubsections "remote"))}))))
+
+
+(defn walk-all-commits
+  "Walk all commits in reverse topological order.
+
+   repo - the repository to walk
+
+   imported-commits - a (possibily empty) map of {sha commitid ...}
+
+   rev-str - an optional git revision string
+
+   Returns a lazy sequence of RevCommit objects. The walk will
+   efficiently skip over SHAs that are keys in the imported-commits map."
+  [^Repository repo
+   imported-commits
+   & rev-str]
+  (let [rev-walk (RevWalk. repo)
+        commit-id
+        (if rev-str
+          (or (.resolve repo ^String rev-str)
+              (throw (ex-info (str "Can't resolve git revision string." rev-str)
+                              {:revision-string rev-str})))
+          (.. repo (getRef "refs/heads/master") (getObjectId)))
+        rev-commit (.parseCommit rev-walk commit-id)
+        rev-filter
+        (proxy [RevFilter] []
+          (clone [] this)
+          (include [rev-walk rev-commit]
+            (nil? (imported-commits (.getName ^RevCommit rev-commit))))
+          (requiresCommitBody [] false))]
+    (seq (doto rev-walk
+           (.markStart rev-commit)
+           (.setRevFilter rev-filter)
+           (.sort RevSort/TOPO true)
+           (.sort RevSort/REVERSE true)))))
+
+
+(defn extract-commit-info
+  "Returns a map of information extracted from a RevCommit object."
+  [^RevCommit commit]
+  (let [author (.getAuthorIdent commit)
+        committer (.getCommitterIdent commit)]
+    {:sha (.getName commit)
+     :msg (.getFullMessage commit)
+     :tree (.. commit (getTree) (getName))
+     :parents (->> commit
+                   (.getParents)
+                   (map #(.getName ^RevCommit %)))
+     :author (.getEmailAddress author)
+     :authored (.getWhen author)
+     :committer (.getEmailAddress committer)
+     :committed (.getWhen committer)}))
+
+
+(defn lookup-rev-tree
+  "Return the RevTree object that resolves from a tree SHA id"
+  [^Repository repo
+   ^String sha]
+  (->> sha
+       (.resolve repo)
+       (.parseTree (RevWalk. repo))))
+
+
+(defn shallow-tree-walk
+  "Walks one level of a RevTree object,
+  returning the trees and blobs contained therein.
+
+  Returns [[sha (:tree OR :blob) file-name] ...]"
+  [^Repository repo
+   ^RevTree tree]
+  (let [tree-walk (doto (TreeWalk. repo)
+                    (.addTree tree)
+                    (.setRecursive false))
+        dir (transient [])]
+    (while (.next tree-walk)
+      (conj! dir
+             [(.. tree-walk (getObjectId 0) (getName))
+              (if (= (.getFileMode tree-walk 0)
+                     FileMode/TREE)
+                :tree :blob)
+              (.getNameString tree-walk)]))
+    (persistent! dir)))
+

--- a/src/datomic/codeq/git.clj
+++ b/src/datomic/codeq/git.clj
@@ -46,7 +46,7 @@
    efficiently skip over SHAs that are keys in the imported-commits map."
   [^Repository repo
    imported-commits
-   & rev-str]
+   rev-str]
   (let [rev-walk (RevWalk. repo)
         commit-id
         (if rev-str

--- a/test/datomic/codeq/core_test.clj
+++ b/test/datomic/codeq/core_test.clj
@@ -1,7 +1,390 @@
 (ns datomic.codeq.core-test
   (:use clojure.test
-        datomic.codeq.core))
+        datomic.codeq.core
+        datomic.codeq.util
+        datomic.codeq.test-datomic-util
+        datomic.codeq.test-git-util)
+  (:require [datomic.codeq.git :as git]
+            [datomic.api :as d]
+            [clojure.java.io :as io]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 1 1))))
+
+(def ^:dynamic *conn*
+  "A dynamic var to hold the Datomic connection."
+  nil)
+
+(def ^:dynamic *git*
+  "A dynamic var to hold the GitPorcelain API."
+  nil)
+
+(def ^:dynamic *repo*
+  "A dynamic var to hold the Git repository."
+  nil)
+
+(def ^:dynamic *repo-dir*
+  "A dynamic var to hold a File object to the repository directory."
+  nil)
+
+
+(defn datomic-fixture
+  [f]
+  (let [uri (str "datomic:mem://" (d/squuid))]
+    (d/create-database uri)
+    (let [c (d/connect uri)]
+      @(d/transact c schema)
+      (binding [*conn* c]
+        (f)))
+    (d/delete-database uri)))
+
+(defn git-fixture
+  [f]
+  (let [d (create-temp-dir)
+        [g r] (init-repo d)]
+    (binding [*git* g
+              *repo* r
+              *repo-dir* d]
+      (f))))
+
+(use-fixtures :each (compose-fixtures datomic-fixture git-fixture))
+
+
+(defmacro is-only
+  [x coll]
+  `(do
+     (is (= 1 (count ~coll)))
+     (is (= ~x (first ~coll)))))
+
+(defmacro is-coll
+  [coll-expected coll-found]
+  `(let [c# ~coll-found]
+     (do
+      (is (= (count ~coll-expected)
+             (count c#)))
+      (are [e#]
+           (some #(= e# %) c#)
+           ~@coll-expected))))
+
+
+(deftest test-extract-and-import-commit
+  (testing "creating, extracting, and importing a commit:"
+    (let [commit (do
+                   (spit (io/file *repo-dir* "a.txt") "contents of a\n")
+                   (add-file-to-index *git* "a.txt")
+                   (git/extract-commit-info
+                    (git-commit-all *git* "added a.txt\n")))]
+
+      (testing "extract the map of commit information"
+        (is (= "author@example.org"
+               (:author commit)))
+        (is (= "committer@example.org"
+               (:committer commit)))
+        (is (empty? (:parents commit)))
+        (is (= "added a.txt\n"
+               (:msg commit))))
+
+      (testing "importing the commit"
+        (let [repoid (transact-repo-uri *conn* "test/.git")
+              {db :db-after}
+              @(d/transact *conn*
+                           (commit-tx-data (d/db *conn*) *repo* repoid "test" commit))
+              root-tree-node
+              (get-root-tree-node db (:sha commit))
+              children
+              (get-tree-node-children root-tree-node)]
+          (is (= 1 (count children)))
+          (let [node (first children)]
+            (is (= "a.txt" (node-name node)))
+            (is (= '("test/a.txt") (node-paths node)))))))))
+
+
+(deftest test-file-append
+  (testing "a linear history of two commits, where a file is updated:"
+    (let [f (io/file *repo-dir* "a.txt")
+          c1 (do
+               (spit f "line 1\n")
+               (add-file-to-index *git* "a.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added a.txt")))
+          c2 (do
+               (spit f "line 2\n" :append true)
+               (git/extract-commit-info
+                (git-commit-all *git* "updated a.txt")))
+          repoid (transact-repo-uri *conn* "test/.git")
+          _ (doseq [c [c1 c2]]
+              @(d/transact *conn*
+                           (commit-tx-data (d/db *conn*) *repo* repoid "test" c)))
+          db (d/db *conn*)]
+
+      (testing "examining first commit"
+        (is-only "a.txt"
+                 (find-commit-filenames db (:sha c1)))
+        (is-only "test/a.txt"
+                 (find-commit-filepaths db (:sha c1)))
+        ;;hardcoded sha corresponds to "line 1\n"
+        (is-only (:sha c1)
+                 (find-blob-commits db "89b24ecec50c07aef0d6640a2a9f6dc354a33125")))
+
+      (testing "examining second commit"
+        (is-only "a.txt"
+                 (find-commit-filenames db (:sha c2)))
+        (is-only "test/a.txt"
+                 (find-commit-filepaths db (:sha c2)))
+        ;;hardcoded sha corresponds to "line 1\nline 2\n"
+        (is-only (:sha c2)
+                 (find-blob-commits db "7bba8c8e64b598d317cdf1bb8a63278f9fc241b1")))
+
+      (testing "finding commits by file name and path"
+        (is-coll [(:sha c1) (:sha c2)]
+                 (find-filename-commits db "a.txt"))
+        (is-coll [(:sha c1) (:sha c2)]
+                 (find-filepath-commits db "test/a.txt"))))))
+
+
+(deftest test-rename-file
+  (testing "a linear history of two commits, where a file is renamed:"
+    (let [f1 (io/file *repo-dir* "a.txt")
+          c1 (do
+               (spit f1 "line 1\n")
+               (add-file-to-index *git* "a.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added a.txt")))
+          f2 (io/file *repo-dir* "b.txt")
+          c2 (do
+               (io/copy f1 f2)
+               (io/delete-file f1)
+               (add-file-to-index *git* "b.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "renamed a.txt to b.txt")))
+          repoid (transact-repo-uri *conn* "test/.git")
+          _ (doseq [c [c1 c2]]
+              @(d/transact *conn*
+                           (commit-tx-data (d/db *conn*) *repo* repoid "test" c)))
+          db (d/db *conn*)]
+
+      (testing "examining first commit"
+        (is-only "a.txt"
+                 (find-commit-filenames db (:sha c1))))
+
+      (testing "examining second commit"
+        (is-only "b.txt"
+                 (find-commit-filenames db (:sha c2))))
+
+      (testing "finding commits by file contents"
+        (is-coll [(:sha c1) (:sha c2)]
+                 (find-blob-commits db "89b24ecec50c07aef0d6640a2a9f6dc354a33125"))))))
+
+
+(deftest test-merge-commit
+  (testing "a branch and recursive merge in one file:"
+    (let [f (io/file *repo-dir* "a.txt")
+          c1 (do
+               (spit f "line 1\n")
+               (add-file-to-index *git* "a.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added a.txt\n")))
+          c2 (do
+               (checkout-branch *git* "branch" true)
+               (spit f "line 0\nline 1\n")
+               (git/extract-commit-info
+                (git-commit-all *git* "prepended a line to a.txt\n")))
+          c3 (do
+               (checkout-branch *git* "master")
+               (spit f "line 1\nline 2\n")
+               (git/extract-commit-info
+                (git-commit-all *git* "appended a line to a.txt\n")))
+          c4 (do
+               (merge-branch-no-commit *git* "branch")
+               (git/extract-commit-info
+                (git-commit-all *git* (str "Merged branch 'branch'\n"))))
+          repoid (transact-repo-uri *conn* "test/.git")
+          _ (doseq [c [c1 c2 c3 c4]]
+              @(d/transact *conn*
+                           (commit-tx-data (d/db *conn*) *repo* repoid "test" c)))
+          db (d/db *conn*)]
+
+      (testing "examining initial commit on master"
+        (is-only (:sha c1)
+                 (find-blob-commits db "89b24ecec50c07aef0d6640a2a9f6dc354a33125")))
+
+      (testing "examining second commit on branch"
+        (is-only (:sha c1)
+                 (:parents c2))
+        (is-only (:sha c2)
+                 (find-blob-commits db "2bbfc232c2e71c62004c15806843df3ffc3688d0")))
+
+      (testing "examining third commit on master"
+        (is-only (:sha c1)
+                 (:parents c3))
+        (is-only (:sha c3)
+                 (find-blob-commits db "7bba8c8e64b598d317cdf1bb8a63278f9fc241b1")))
+
+      (testing "examining merge commit"
+        (is-coll [(:sha c2) (:sha c3)]
+                 (:parents c4))
+        (is-only (:sha c4)
+                 (find-blob-commits db "73fc08f0c8b6a87eaad8f5991df3a150b501462d")))
+
+      (testing "finding commits by file name and path"
+        (is-coll [(:sha c1) (:sha c2) (:sha c3) (:sha c4)]
+                 (find-filename-commits db "a.txt"))
+        (is-coll [(:sha c1) (:sha c2) (:sha c3) (:sha c4)]
+                 (find-filepath-commits db "test/a.txt"))))))
+
+
+(deftest test-mix-of-file-ops
+  (testing "a linear history of five commits, involving add, update, delete, revert:"
+    (let [f (io/file *repo-dir* "a.txt")
+          ;;start with initial commit of two files a.txt and b.txt
+          c1 (do
+               (spit f "line 1\n")
+               (add-file-to-index *git* "a.txt")
+               (spit (io/file *repo-dir* "b.txt")
+                     "contents of b.txt\n")
+               (add-file-to-index *git* "b.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added a.txt and b.txt\n")))
+          ;;then update a.txt by appending a line, and adding a new
+          ;;file c.txt
+          c2 (do
+               (spit f "line 2\n" :append true)
+               (spit (io/file *repo-dir* "c.txt")
+                     "contents of c.txt\n")
+               (add-file-to-index *git* "c.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "updated a.txt and added c.txt\n")))
+          ;;then add a new file d.txt
+          g (io/file *repo-dir* "d.txt")
+          c3 (do
+               (spit g "contents of d.txt\n")
+               (add-file-to-index *git* "d.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added d.txt\n")))
+          ;;then only to delete that file -- this is equivalent to
+          ;;reverting commit c3
+          c4 (do
+               (io/delete-file g)
+               (git/extract-commit-info
+                (git-commit-all *git* "deleted d.txt\n")))
+          ;;finally, revert file a.txt to how it was after the
+          ;;first commit
+          c5 (do
+               (spit f "line 1\n")
+               (git/extract-commit-info
+                (git-commit-all *git* "revert a.txt\n")))
+          repoid (transact-repo-uri *conn* "test/.git")
+          _ (doseq [c [c1 c2 c3 c4 c5]]
+              @(d/transact *conn*
+                           (commit-tx-data (d/db *conn*) *repo* repoid "test" c)))
+          db (d/db *conn*)]
+
+      (testing "examining first commit"
+        (is-coll ["a.txt" "b.txt"]
+                 (find-commit-filenames db (:sha c1))))
+
+      (testing "finding commits with blobs containing 'line 1\\n'"
+        ;;TODO might have expected c5 here?
+        (is-only (:sha c1)
+                 (find-blob-commits db "89b24ecec50c07aef0d6640a2a9f6dc354a33125")))
+
+      (testing "examining second commit"
+        (is-coll ["a.txt" "c.txt"]
+                 (find-commit-filenames db (:sha c2))))
+
+      (testing "finding commits with blobs containing 'line 1\\nline 2\\n'"
+        ;;TODO this is because c4 has the same root tree as c2 as
+        ;;it reverted c3
+        (is-coll [(:sha c2) (:sha c4)]
+                 (find-blob-commits db "7bba8c8e64b598d317cdf1bb8a63278f9fc241b1")))
+
+      (testing "examining third commit"
+        (is-only "d.txt"
+                 (find-commit-filenames db (:sha c3))))
+
+      (testing "examining fourth commit"
+        ;;TODO as said above, c2 and c4 share a root tree
+        (is-coll ["a.txt" "c.txt"]
+                 (find-commit-filenames db (:sha c4))))
+
+      (testing "examining fifth commit"
+        ;;TODO maybe a tad surprising?
+        (is (empty? (find-commit-filenames db (:sha c5)))))
+
+      (testing "find commits"
+        ;;TODO might have expected c5 here?
+        (is-coll [(:sha c1) (:sha c2) (:sha c4)]
+                 (find-filename-commits db "a.txt"))))))
+
+
+(deftest test-path-trickery
+  (testing "a linear history of four commits, to examine file path behavior:"
+    (let [;;start with an initial commit of file a.txt in
+          ;;subdirectory d1
+          dir1 (doto (io/file *repo-dir* "d1") (.mkdir))
+          f1 (io/file dir1 "a.txt")
+          c1 (do
+               (spit f1 "line 1\n")
+               (add-file-to-index *git* "d1/a.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added d1/a.txt\n")))
+          ;;then add a file with the same name but distinct
+          ;;contents into subdirectory d2
+          dir2 (doto (io/file *repo-dir* "d2") (.mkdir))
+          f2 (io/file dir2 "a.txt")
+          c2 (do
+               (spit f2 "line 2\n")
+               (add-file-to-index *git* "d2/a.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added d2/a.txt\n")))
+          ;;then add a file with the same name and contents as the
+          ;;previous commit but in subdirectory d3
+          dir3 (doto (io/file *repo-dir* "d3") (.mkdir))
+          f3 (io/file dir3 "a.txt")
+          c3 (do
+               (spit f3 "line 2\n")
+               (add-file-to-index *git* "d3/a.txt")
+               (git/extract-commit-info
+                (git-commit-all *git* "added d3/a.txt\n")))
+          ;;the repository is now is a state where there are three
+          ;;files, all of which have the same name, two of which
+          ;;have the same content, and all are in distinct
+          ;;subdirectories
+          ;;finally overwrite the contents of d2/a.txt with the
+          ;;contents of d1/a.txt
+          c4 (do
+               (spit f2 "line 1\n")
+               (git/extract-commit-info
+                (git-commit-all *git* "copied d1/a.txt to d2/a.txt\n")))
+          ;;before, two files contained 'line 2\\n'
+          ;;now, two files contain 'line 1\\n'
+          repoid (transact-repo-uri *conn* "test/.git")
+          _ (doseq [c [c1 c2 c3 c4]]
+              @(d/transact *conn*
+                           (commit-tx-data (d/db *conn*) *repo* repoid "test" c)))
+          db (d/db *conn*)]
+
+      (testing "find commits with file a.txt"
+        (is-coll [(:sha c1) (:sha c2) (:sha c3) (:sha c4)]
+                 (find-filename-commits db "a.txt")))
+
+      (testing "find commits with path d1/a.txt"
+        ;;TODO might have expected just c1?
+        (is-coll [(:sha c1) (:sha c4)]
+                 (find-filepath-commits db "test/d1/a.txt")))
+
+      (testing "find commits with path d2/a.txt"
+        ;;TODO might have expected just c2 and c4?
+        (is-coll [(:sha c1) (:sha c2) (:sha c3) (:sha c4)]
+                 (find-filepath-commits db "test/d2/a.txt")))
+
+      (testing "find commits with path d3/a.txt"
+        ;;TODO might have expected just c3?
+        (is-coll [(:sha c2) (:sha c3)]
+                 (find-filepath-commits db "test/d3/a.txt")))
+
+      (testing "find commits for blob with contents 'line 1\\n'"
+        (is-coll [(:sha c1) (:sha c4)]
+                 (find-blob-commits db "89b24ecec50c07aef0d6640a2a9f6dc354a33125")))
+
+      (testing "find commits for blob with contents 'line 2\\n'"
+        (is-coll [(:sha c2) (:sha c3)]
+                 (find-blob-commits db "b7e242c00cdad96cf88a626557eba4deab43b52f"))))))

--- a/test/datomic/codeq/test_datomic_util.clj
+++ b/test/datomic/codeq/test_datomic_util.clj
@@ -1,0 +1,188 @@
+(ns datomic.codeq.test-datomic-util
+  (:use [datomic.codeq.util :only [index-get-id]]
+        [datomic.codeq.core :only [schema]])
+  (:require [datomic.api :as d]))
+
+
+;; Transact Helpers
+
+(defn transact-repo-uri
+  "Transact the given repository uri.
+   Returns the entity id of the transacted fact."
+  [conn repo-uri]
+  (let [id (d/tempid :db.part/user)
+        {:keys [db-after tempids]}
+        @(d/transact conn [[:db/add id :repo/uri repo-uri]])
+        repoid (d/resolve-tempid db-after tempids id)]
+    repoid))
+
+
+;; Query Helpers
+
+(def rules
+  '[;;find all blobs ?b that are decendants of tree node ?n
+    [(node-blobs ?n ?b)
+     [?n :node/object ?b] [?b :git/type :blob]]
+    [(node-blobs ?n ?b)
+     [?n :node/object ?t] [?t :git/type :tree]
+     [?t :tree/nodes ?n2] (node-files ?n2 ?b)]
+
+    ;;find all file names ?name for blobs that are decendants of tree
+    ;;node ?n
+    [(node-files ?n ?name)
+     [?n :node/object ?b] [?b :git/type :blob]
+     [?n :node/filename ?f] [?f :file/name ?name]]
+    [(node-files ?n ?name)
+     [?n :node/object ?t] [?t :git/type :tree]
+     [?t :tree/nodes ?n2] (node-files ?n2 ?name)]
+
+    ;;find all file paths ?path for blobs that are decendants of tree
+    ;;node ?n
+    [(node-paths ?n ?path)
+     [?n :node/object ?b] [?b :git/type :blob]
+     [?n :node/paths ?p] [?p :file/name ?path]]
+    [(node-paths ?n ?path)
+     [?n :node/object ?t] [?t :git/type :tree]
+     [?t :tree/nodes ?n2] (node-paths ?n2 ?path)]
+
+    ;;find all tree nodes ?n that reference this object (blob/tree) or
+    ;;are ancestors of tree nodes that do
+    [(object-nodes ?o ?n)
+     [?n :node/object ?o]]
+    [(object-nodes ?o ?n)
+     [?n2 :node/object ?o]
+     [?t :tree/nodes ?n2] (object-nodes ?t ?n)]
+
+    ;;find all tree nodes ?n that have file name ?name or are
+    ;;ancestors of tree nodes that do
+    [(file-nodes ?name ?n)
+     [?f :file/name ?name] [?n :node/filename ?f]]
+    [(file-nodes ?name ?n)
+     (file-nodes ?name ?n2)
+     [?t :tree/nodes ?n2] [?n :node/object ?t]]
+
+    ;;find all tree nodes ?n that have file path ?path or are
+    ;;ancestors of tree nodes that do
+    [(path-nodes ?path ?n)
+     [?p :file/name ?path] [?n :node/paths ?p]]
+    [(path-nodes ?path ?n)
+     (path-nodes ?path ?n2)
+     [?t :tree/nodes ?n2] [?n :node/object ?t]]
+
+    ;;find all blobs ?b that are within commit ?c's tree
+    [(commit-blobs ?c ?b)
+     [?c :commit/tree ?root] (node-blobs ?root ?b)]
+
+    ;;find all file names ?name that are within commit ?c's tree
+    [(commit-files ?c ?name)
+     [?c :commit/tree ?root] (node-files ?root ?name)]
+
+    ;;find all file paths ?path that are within commit ?c's tree
+    [(commit-paths ?c ?path)
+     [?c :commit/tree ?root] (node-paths ?root ?path)]
+
+    ;;find all codeqs ?cq for blobs that are within commit ?c's tree
+    [(commit-codeqs ?c ?cq)
+     (commit-blobs ?c ?b) [?cq :codeq/file ?b]]
+
+    ;;find all commits ?c that include blob ?b
+    [(blob-commits ?b ?c)
+     (object-nodes ?b ?n) [?c :commit/tree ?n]]
+
+    ;;find all commits ?c that include a file named ?name
+    [(file-commits ?name ?c)
+     (file-nodes ?name ?n) [?c :commit/tree ?n]]
+
+    ;;find all commits ?c that include a file path named ?path
+    [(path-commits ?path ?c)
+     (path-nodes ?path ?n) [?c :commit/tree ?n]]
+
+    ;;find all commits ?c that include a codeq ?cq
+    [(codeq-commits ?cq ?c)
+     [?cq :codeq/file ?b] (blob-commits ?b ?c)]])
+
+
+(defn find-commit-filenames
+  "Returns all file names that are part of the given commit."
+  [db commit-sha]
+  (mapv first
+        (d/q '[:find ?name
+               :in $ % ?sha
+               :where
+               [?c :git/sha ?sha]
+               (commit-files ?c ?name)]
+             db rules commit-sha)))
+
+(defn find-commit-filepaths
+  "Returns all file paths that are part of the given commit."
+  [db commit-sha]
+  (mapv first
+        (d/q '[:find ?path
+               :in $ % ?sha
+               :where
+               [?c :git/sha ?sha]
+               (commit-paths ?c ?path)]
+             db rules commit-sha)))
+
+(defn find-filename-commits
+  "Returns all commits that reference the given file name."
+  [db filename]
+  (mapv first
+        (d/q '[:find ?sha
+               :in $ % ?name
+               :where
+               (file-commits ?name ?c)
+               [?c :git/sha ?sha]]
+             db rules filename)))
+
+(defn find-filepath-commits
+  "Returns all commits that reference the given file path."
+  [db path]
+  (mapv first
+        (d/q '[:find ?sha
+               :in $ % ?path
+               :where
+               (path-commits ?path ?c)
+               [?c :git/sha ?sha]]
+             db rules path)))
+
+
+(defn find-blob-commits
+  "Returns all commits that reference the given blob sha."
+  [db blob-sha]
+  (let [blob-id (index-get-id db :git/sha blob-sha)]
+    (mapv first
+          (d/q '[:find ?sha
+                 :in $ % ?blob-id
+                 :where
+                 (blob-commits ?blob-id ?c)
+                 [?c :git/sha ?sha]]
+               db rules blob-id))))
+
+
+;; Entity Helpers
+
+(defn get-root-tree-node
+  "Returns the root tree node entity for the given commit sha."
+  [db commit-sha]
+  (->> (d/datoms db :avet :git/sha commit-sha)
+       first :e (d/entity db) :commit/tree))
+
+(defn node-name
+  "Returns the file name of a tree node entity."
+  [tree-node-entity]
+  (get-in tree-node-entity [:node/filename :file/name]))
+
+(defn node-paths
+  "Returns the file paths of a tree node entity."
+  [tree-node-entity]
+  (->> tree-node-entity
+       :node/paths
+       (map :file/name)))
+
+(defn get-tree-node-children
+  "Returns the children tree nodes of a tree node."
+  [tree-node-entity]
+  (let [o (:node/object tree-node-entity)]
+    (assert (= :tree (:git/type o)))
+    (:tree/nodes o)))

--- a/test/datomic/codeq/test_git_util.clj
+++ b/test/datomic/codeq/test_git_util.clj
@@ -1,0 +1,87 @@
+(ns datomic.codeq.test-git-util
+  (:import java.io.File
+           java.nio.file.Files
+           java.nio.file.attribute.FileAttribute
+           org.eclipse.jgit.api.Git
+           org.eclipse.jgit.lib.PersonIdent))
+
+
+(defn create-temp-dir
+  "Returns a java.io.File handle to a fresh temporary directory."
+  []
+  (.toFile (Files/createTempDirectory "codeqtest" (into-array FileAttribute []))))
+
+
+(defn init-repo
+  "Returns a GitPorcelain API object and an initialized git
+   repository for the given directory."
+  [dir]
+  (let [git (.. (Git/init) (setDirectory dir) (call))]
+    [git (.getRepository git)]))
+
+
+(defn create-person-ident
+  "Returns a PersonIdent from the name and num
+   with the current timestamp."
+  [name num]
+  (let [ident (str name num)
+        email (str ident "@example.org")]
+    (PersonIdent. ident email)))
+
+
+(defn author-ident
+  "Returns a PersonIdent called 'author'."
+  [& [num]]
+  (create-person-ident "author" num))
+
+
+(defn committer-ident
+  "Returns a Personident called 'committer'."
+  [& [num]]
+  (create-person-ident "committer" num))
+
+
+(defn add-file-to-index
+  "Add the given file name to the git index."
+  [git name]
+  (.. git (add) (addFilepattern name) (call)))
+
+
+(defn git-commit-all
+  "Perform a git commit.
+   Equivalent to
+     git commit -a -m msg"
+  [git msg]
+  (.. git (commit)
+      (setAll true)
+      (setAuthor (author-ident))
+      (setCommitter (committer-ident))
+      (setMessage msg)
+      (call)))
+
+
+(defn checkout-branch
+  "Perform a git checkout.
+     git checkout branch-name
+   If is-new is true then the branch is created.
+     git checkout -b branch-name"
+  [git branch-name & [is-new]]
+  (.. git
+      (checkout)
+      (setCreateBranch (true? is-new))
+      (setName branch-name)
+      (call)))
+
+
+(defn merge-branch-no-commit
+  "Perform a git merge, but stopping before committing.
+   Equivalent to
+     git merge --no-commit branch-name"
+  [git branch-name]
+  (let [repo (.getRepository git)
+        branch-id (.resolve repo branch-name)]
+    (.. git
+        (merge)
+        (include branch-id)
+        (setCommit false)
+        (call))))


### PR DESCRIPTION
This pull request replaces the use of `Runtime.exec` to invoke git, with the use of the [JGit](http://eclipse.org/jgit) library. This appears to result in much faster import and analysis times. Aside from the new functions, the major change to `datomic.codeq.core` is the need to pass around an instance of [`org.eclipse.jgit.lib.Repository`](http://download.eclipse.org/jgit/docs/latest/apidocs/org/eclipse/jgit/lib/Repository.html).
